### PR TITLE
adding build for self-hosted plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ plugin/android/app/src/main/jniLibs
 
 test/android/.idea
 plugin/android/.idea
+plugin/ios/BuiltPlugin

--- a/plugin/ios/App.xcodeproj/project.pbxproj
+++ b/plugin/ios/App.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 				9DD299B321F725350054DA79 /* MainWindow-iPad.xib */,
 			);
 			name = resource;
-			path = "../../../../../../Applications/Corona-3573/Native/Corona/ios/resource";
+			path = "$HOME/Library/Application Support/Corona/Native/Corona/ios/resource";
 			sourceTree = "<group>";
 		};
 		A447B66F16670015009EA762 /* CoronaNative */ = {

--- a/plugin/ios/build.sh
+++ b/plugin/ios/build.sh
@@ -3,7 +3,7 @@
 path=$(dirname "$0")
 
 OUTPUT_DIR=$1
-TARGET_NAME=plugin_library
+TARGET_NAME=plugin_adjust
 OUTPUT_SUFFIX=a
 CONFIG=Release
 
@@ -108,8 +108,15 @@ build_plugin_structure() {
 	else
 		echo "No 3rd party frameworks"
 	fi
+
+	(
+		SFNAME="$TARGET_NAME-$(basename "$PLUGIN_DEST").tgz"
+		cd "$PLUGIN_DEST"
+		COPYFILE_DISABLE=true tar -czvf ../"$SFNAME" --exclude=".*" *
+	)
 }
 
+rm -r "$path/BuiltPlugin"
 
 
 build_plugin_structure "$OUTPUT_DIR/BuiltPlugin/iphone" iphoneos  " -extract armv7 -extract  arm64 "

--- a/plugin/ios/metadata.lua
+++ b/plugin/ios/metadata.lua
@@ -3,8 +3,8 @@ local metadata =
 	plugin =
 	{
 		format = 'staticLibrary',
-		staticLibs = { 'plugin_library', },
-		frameworks = {},
+		staticLibs = { 'plugin_adjust' },
+		frameworks = { 'AdSupport', 'CoreTelephony', },
 		frameworksOptional = {},
 		-- usesSwift = true,
 	},


### PR DESCRIPTION
Editing `build.sh` script to generate self-hosted archives, so users can build iOS Apps from the simulator. When uploaded to the host, build settings entry looks like:
```lua
    plugins = 
    {
        ["plugin.adjust"] =
        {
            publisherId = "com.adjust",
            supportedPlatforms = { 
            	iphone={url="https://vlad-test.s3.amazonaws.com/plugin_adjust-iphone.tgz"},
            	["iphone-sim"]={url="https://vlad-test.s3.amazonaws.com/plugin_adjust-iphone-sim.tgz"},
            }
        },
    }
```